### PR TITLE
feat: add docker healthcheck to LNMP containers

### DIFF
--- a/assets/scripts/healthcheck.sh
+++ b/assets/scripts/healthcheck.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# LEMP Docker Healthcheck Script
+# Verifies that all essential services are running and responsive
+
+set -e
+
+# Flags for service status
+nginx_ok=false
+mysql_ok=false
+
+# Check Nginx
+if curl -sf http://127.0.0.1/ > /dev/null 2>&1; then
+    nginx_ok=true
+fi
+
+# Check MariaDB/MySQL
+if mysqladmin -h 127.0.0.1 ping > /dev/null 2>&1; then
+    mysql_ok=true
+fi
+
+# Both services must be healthy
+if [ "$nginx_ok" = true ] && [ "$mysql_ok" = true ]; then
+    exit 0
+else
+    echo "Health check failed: nginx=$nginx_ok, mysql=$mysql_ok"
+    exit 1
+fi

--- a/flavors/phalcon/Dockerfile.dev
+++ b/flavors/phalcon/Dockerfile.dev
@@ -1,1 +1,1 @@
-../vanilla/Dockerfile.dev
+../vanilla/dev/Dockerfile

--- a/flavors/phalcon/Dockerfile.prod
+++ b/flavors/phalcon/Dockerfile.prod
@@ -1,1 +1,1 @@
-../vanilla/Dockerfile.prod
+../vanilla/prod/Dockerfile.prod

--- a/flavors/vanilla/dev/Dockerfile
+++ b/flavors/vanilla/dev/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get update && \
 COPY --from=builder /var/www/html/pma /var/www/html/pma
 
 COPY ../../assets/scripts/docker-entrypoint.sh /entrypoints/3-mariadb-entrypoint.sh
+COPY ../../assets/scripts/healthcheck.sh /healthcheck.sh
 COPY ../../assets/phpmyadmin/config.inc.php /var/www/html/pma/config.inc.php
 COPY ../../assets/mariadb/50-server.cnf /etc/mysql/mariadb.conf.d/50-server.cnf
 COPY ../../assets/nginx/pma.conf /etc/nginx/custom-conf/01-pma.conf
@@ -56,7 +57,7 @@ COPY ../../assets/monit/mariadb /etc/monit/conf-enabled/
 COPY ../../assets/scripts/build.sql /
 
 # Setup database, create phpMyAdmin session directory with secure permissions, and fix ownership
-RUN chmod +x /entrypoints/3-mariadb-entrypoint.sh && \
+RUN chmod +x /entrypoints/3-mariadb-entrypoint.sh /healthcheck.sh && \
     /etc/init.d/mariadb start && \
     sleep 5 && \
     mysql < /build.sql && \
@@ -66,3 +67,4 @@ RUN chmod +x /entrypoints/3-mariadb-entrypoint.sh && \
 
 USER www-data
 ENTRYPOINT ["/docker-entrypoint.sh"]
+HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 CMD /healthcheck.sh

--- a/flavors/vanilla/prod/Dockerfile
+++ b/flavors/vanilla/prod/Dockerfile
@@ -20,12 +20,13 @@ RUN apt-get update && apt-get upgrade -y && \
 
 # Copy configuration files and scripts
 COPY ../../assets/scripts/docker-entrypoint-prod.sh /entrypoints/3-mariadb-entrypoint.sh
+COPY ../../assets/scripts/healthcheck.sh /healthcheck.sh
 COPY ../../assets/mariadb/50-server-prod.cnf /etc/mysql/mariadb.conf.d/50-server.cnf
 COPY ../../assets/monit/mariadb /etc/monit/conf-enabled/
 COPY ../../assets/scripts/build-prod.sql /
 
 # Setup database, create SQL scripts directory, and fix permissions in one optimized layer
-RUN chmod +x /entrypoints/3-mariadb-entrypoint.sh && \
+RUN chmod +x /entrypoints/3-mariadb-entrypoint.sh /healthcheck.sh && \
     /etc/init.d/mariadb start && \
     sleep 5 && \
     mysql < /build-prod.sql && \
@@ -35,3 +36,4 @@ RUN chmod +x /entrypoints/3-mariadb-entrypoint.sh && \
 
 USER www-data
 ENTRYPOINT ["/docker-entrypoint.sh"]
+HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 CMD /healthcheck.sh

--- a/flavors/vanilla/prod/Dockerfile
+++ b/flavors/vanilla/prod/Dockerfile
@@ -34,6 +34,6 @@ RUN chmod +x /entrypoints/3-mariadb-entrypoint.sh /healthcheck.sh && \
     mkdir /sql-scripts && chmod 755 /sql-scripts && \
     chown -R www-data. /sql-scripts /run/mysqld /usr/lib/mysql /var/log/mysql /var/lib/mysql /lib/mysql/ /etc/mysql/
 
+HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 CMD /healthcheck.sh
 USER www-data
 ENTRYPOINT ["/docker-entrypoint.sh"]
-HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 CMD /healthcheck.sh


### PR DESCRIPTION
- Add healthcheck.sh script to verify nginx and mariadb services
- Add HEALTHCHECK instruction to vanilla dev/prod Dockerfiles
- HEALTHCHECK runs every 30s with 40s initial delay and 3 retries
- Fix broken symlinks for phalcon Dockerfile references
- Healthcheck validates both HTTP and MySQL connectivity